### PR TITLE
Webpack for WebStorm

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,18 @@
-const path = require('path')
-/**
+/*
  *  Resolves module aliases in IDEs (WebStorm, etc)
  *
- *  For runtime module alias resolution see `_moduleAliases { }`
- *  in `package.json`
+ *  For runtime module alias resolution see
+ *  https://www.npmjs.com/package/module-alias
  */
+const {
+  _moduleAliases
+} = require('./package.json')
+
 module.exports = {
   mode: 'production',
   resolve: {
     alias: {
-      '~': path.resolve(__dirname, './lib')
+      ..._moduleAliases
     }
   }
 }


### PR DESCRIPTION
[FB-779](https://dsdmoj.atlassian.net/browse/FB-779)

- Modified the `webpack.config.js` to always keep aliases in sync with the package

Module aliases were meant to be short-term. Long-term: [kill the dependencies altogether](https://dsdmoj.atlassian.net/browse/FB-794)