### PR TITLE
Remove support for `fileupload` components

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,3 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 2
-
-[*.sh]
-end_of_line = lf

--- a/lib/admin/route/admin.instance.create.type/admin.instance.create.type.controller.js
+++ b/lib/admin/route/admin.instance.create.type/admin.instance.create.type.controller.js
@@ -29,7 +29,6 @@ const defaultOrder = [
   'textarea',
   'radios',
   'checkboxes',
-  'fileupload',
   'fieldset',
   'group',
   'section',

--- a/lib/admin/route/admin.instance/admin.instance.controller.js
+++ b/lib/admin/route/admin.instance/admin.instance.controller.js
@@ -529,7 +529,7 @@ async function setData (pageInstance, pageData, POST, REFERRER) {
       if (instanceType.startsWith('page.')) {
         excluded = excluded.concat(['repeatable'])
       }
-      if (instanceType === 'fileupload' || instanceType === 'upload') {
+      if (instanceType === 'upload') {
         excluded = excluded.concat(['repeatable'])
       }
       if (excluded.length) {

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -6,6 +6,11 @@ const {
   unlinkSync
 } = require('fs')
 
+const {
+  hasFileUploadComponentInForm,
+  transformFileUploadComponentsInForm
+} = require('@ministryofjustice/fb-transformers')
+
 const ensureDir = require('ensure-dir')
 const stripAnsi = require('strip-ansi')
 const debug = require('debug')
@@ -33,9 +38,18 @@ module.exports = {
   async start () {
     log('Editor is awake')
 
+    const servicePath = process.env.SERVICE_PATH // || process.env.SERVICEDATA
+    const serviceName = servicePath.replace(/\/$/, '').replace(/.*\//, '')
+
+    if (await hasFileUploadComponentInForm(servicePath)) {
+      log(`Updating file upload components in "${serviceName}" at "${servicePath} ..."`)
+
+      await transformFileUploadComponentsInForm(servicePath)
+
+      log(`... File upload components in "${serviceName}" at "${servicePath} updated"`)
+    }
+
     if (process.env.LOGDIR) {
-      const servicePath = process.env.SERVICE_PATH || process.env.SERVICEDATA
-      const serviceName = servicePath.replace(/\/$/, '').replace(/.*\//, '')
       const logdir = process.env.LOGDIR
 
       await ensureDir(logdir)

--- a/lib/service-data/service-data.js
+++ b/lib/service-data/service-data.js
@@ -7,8 +7,14 @@ const {
 } = require('@ministryofjustice/fb-runner-node/lib/middleware/routes-metadata/routes-metadata')
 
 const {
+  getSchemaNameByCategory,
   loadServiceData
 } = serviceData
+
+/*
+ *  TBR once `fileupload` components are removed from Components
+ */
+serviceData.getSchemaNameByCategory = (category) => getSchemaNameByCategory(category).filter((schemaName) => schemaName !== 'fileupload')
 
 /*
  *  Monkey patch for Editor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1059,6 +1059,25 @@
         "write-file-atomic": "^3.0.3"
       }
     },
+    "@ministryofjustice/fb-transformers": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-transformers/-/fb-transformers-1.0.3.tgz",
+      "integrity": "sha512-MjUzzRyblh9h+4dGu/p6BY139nFptXqcuXk2GmzL0XskhgPV1Ki7PnXSP/v/6VwVwJQMq8tthB09ZhaekRpBtg==",
+      "requires": {
+        "commander": "^5.0.0",
+        "cross-env": "^7.0.2",
+        "debug": "^4.1.1",
+        "glob-all": "^3.1.0",
+        "sacred-fs": "^1.0.14"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
+          "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ=="
+        }
+      }
+    },
     "@ministryofjustice/module-alias": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/@ministryofjustice/module-alias/-/module-alias-1.0.13.tgz",
@@ -13897,8 +13916,7 @@
     "sacred-fs": {
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/sacred-fs/-/sacred-fs-1.0.14.tgz",
-      "integrity": "sha512-whXJo0TWOAJKFmG+0Z26/EEc4Lz5VHtHG/sngxfWLVC9bpP9y5+10PrzeOm3qKK7EayJYmPALFKljUOBL1lyBQ==",
-      "dev": true
+      "integrity": "sha512-whXJo0TWOAJKFmG+0Z26/EEc4Lz5VHtHG/sngxfWLVC9bpP9y5+10PrzeOm3qKK7EayJYmPALFKljUOBL1lyBQ=="
     },
     "safe-buffer": {
       "version": "5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,12 +65,6 @@
             "minimist": "^1.2.5"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2253,12 +2247,6 @@
         "pify": "^4.0.1"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
@@ -2590,14 +2578,15 @@
       }
     },
     "browserslist": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
-      "integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.10.0.tgz",
+      "integrity": "sha512-TpfK0TDgv71dzuTsEAlQiHeWQ/tiPqgNZVdv046fvNtBZrjbv2O3TsWCDU0AWGJJKCF/KsjNdLzR9hXOsh/CfA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001030",
-        "electron-to-chromium": "^1.3.363",
-        "node-releases": "^1.1.50"
+        "caniuse-lite": "^1.0.30001035",
+        "electron-to-chromium": "^1.3.378",
+        "node-releases": "^1.1.52",
+        "pkg-up": "^3.1.0"
       }
     },
     "buffer": {
@@ -2706,12 +2695,6 @@
           "requires": {
             "yallist": "^3.0.2"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
         },
         "mkdirp": {
           "version": "0.5.3",
@@ -3594,12 +3577,6 @@
         "run-queue": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
@@ -4596,9 +4573,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.378",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz",
-      "integrity": "sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw==",
+      "version": "1.3.379",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.379.tgz",
+      "integrity": "sha512-NK9DBBYEBb5f9D7zXI0hiE941gq3wkBeQmXs1ingigA/jnTg5mhwY2Z5egwA+ZI8OLGKCx0h1Cl8/xeuIBuLlg==",
       "dev": true
     },
     "elliptic": {
@@ -4931,12 +4908,6 @@
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
         },
         "mkdirp": {
           "version": "0.5.3",
@@ -6210,12 +6181,6 @@
         "rimraf": "2"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
@@ -7057,9 +7022,9 @@
           }
         },
         "fsevents": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-          "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+          "version": "1.2.12",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+          "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7113,7 +7078,7 @@
               }
             },
             "chownr": {
-              "version": "1.1.3",
+              "version": "1.1.4",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -7285,7 +7250,7 @@
               }
             },
             "minimist": {
-              "version": "0.0.8",
+              "version": "1.2.5",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -7310,12 +7275,12 @@
               }
             },
             "mkdirp": {
-              "version": "0.5.1",
+              "version": "0.5.3",
               "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
               }
             },
             "ms": {
@@ -7325,7 +7290,7 @@
               "optional": true
             },
             "needle": {
-              "version": "2.4.0",
+              "version": "2.3.3",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -7354,7 +7319,7 @@
               }
             },
             "nopt": {
-              "version": "4.0.1",
+              "version": "4.0.3",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -7379,13 +7344,14 @@
               "optional": true
             },
             "npm-packlist": {
-              "version": "1.4.7",
+              "version": "1.4.8",
               "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
+                "npm-bundled": "^1.0.1",
+                "npm-normalize-package-bin": "^1.0.1"
               }
             },
             "npmlog": {
@@ -7465,18 +7431,10 @@
                 "ini": "~1.3.0",
                 "minimist": "^1.2.0",
                 "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
               }
             },
             "readable-stream": {
-              "version": "2.3.6",
+              "version": "2.3.7",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -8356,12 +8314,6 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
           "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "object-assign": {
@@ -9713,14 +9665,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "jsonlint": {
@@ -10317,14 +10261,6 @@
       "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
       "requires": {
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "optional": true
-        }
       }
     },
     "mamacro": {
@@ -10683,12 +10619,6 @@
             "strip-bom": "^2.0.0"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "parse-json": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -10881,6 +10811,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
     "minimist-options": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.0.2.tgz",
@@ -11070,12 +11005,6 @@
           "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
           "dev": true
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
@@ -11195,12 +11124,6 @@
         "run-queue": "^1.0.3"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
@@ -11241,11 +11164,6 @@
         "xtend": "^4.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
@@ -11288,12 +11206,6 @@
         "rimraf": "~2.4.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "optional": true
-        },
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
@@ -11418,12 +11330,6 @@
         "which": "1"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
@@ -11628,12 +11534,6 @@
             "lru-cache": "^4.0.1",
             "which": "^1.2.9"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
         },
         "mkdirp": {
           "version": "0.5.3",
@@ -12432,6 +12332,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      }
+    },
+    "pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
       "dev": true,
       "requires": {
         "find-up": "^3.0.0"
@@ -15632,12 +15541,6 @@
         "util.promisify": "~1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
@@ -16918,9 +16821,9 @@
           }
         },
         "fsevents": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-          "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+          "version": "1.2.12",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+          "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -16974,7 +16877,7 @@
               }
             },
             "chownr": {
-              "version": "1.1.3",
+              "version": "1.1.4",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -17146,7 +17049,7 @@
               }
             },
             "minimist": {
-              "version": "0.0.8",
+              "version": "1.2.5",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -17171,12 +17074,12 @@
               }
             },
             "mkdirp": {
-              "version": "0.5.1",
+              "version": "0.5.3",
               "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
               }
             },
             "ms": {
@@ -17186,7 +17089,7 @@
               "optional": true
             },
             "needle": {
-              "version": "2.4.0",
+              "version": "2.3.3",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -17215,7 +17118,7 @@
               }
             },
             "nopt": {
-              "version": "4.0.1",
+              "version": "4.0.3",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -17240,13 +17143,14 @@
               "optional": true
             },
             "npm-packlist": {
-              "version": "1.4.7",
+              "version": "1.4.8",
               "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
+                "npm-bundled": "^1.0.1",
+                "npm-normalize-package-bin": "^1.0.1"
               }
             },
             "npmlog": {
@@ -17326,18 +17230,10 @@
                 "ini": "~1.3.0",
                 "minimist": "^1.2.0",
                 "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
               }
             },
             "readable-stream": {
-              "version": "2.3.6",
+              "version": "2.3.7",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -17783,12 +17679,6 @@
             "to-regex": "^3.0.2"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
@@ -18196,12 +18086,6 @@
         "mkdirp": "^0.5.1"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "deep-equal": "^2.0.1",
     "dragula": "^3.7.2",
     "ensure-dir": "^0.1.0",
-    "glob-all": "^3.1.0",
+    "glob-all": "^3.2.1",
     "jsonpath": "^1.0.2",
     "lodash.clonedeep": "^4.5.0",
     "strip-ansi": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "@ministryofjustice/fb-runner-node": "0.1.47",
+    "@ministryofjustice/fb-transformers": "^1.0.3",
     "@ministryofjustice/module-alias": "^1.0.13",
     "ajv": "^6.12.0",
     "autosize": "^4.0.2",


### PR DESCRIPTION
- Implements Transformers to ensure Forms are modified to use `upload` rather than `fileupload` components
- Removes support for `fileupload` components
- Filters `fileupload` components from service data. They are no longer available to Editors