### PR TITLE
Packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,10 @@
     "deep-equal": "^2.0.1",
     "dragula": "^3.7.2",
     "ensure-dir": "^0.1.0",
+    "express": "^4.17.1",
     "glob-all": "^3.2.1",
     "jsonpath": "^1.0.2",
+    "jsonschema": "^1.2.5",
     "lodash.clonedeep": "^4.5.0",
     "strip-ansi": "^6.0.0"
   },


### PR DESCRIPTION
As with **[Runner](https://github.com/ministryofjustice/fb-runner-node/pull/530)**, the plan was to:

- Remove packages which are referenced in `dependencies` or `devDependencies` but not in code
- Add packages which are referenced in code but not in `dependencies` or `devDependencies`

But in fact it only _adds_ packages which are referenced in code but do not feature in either set of dependencies. (They are still installed because they are dependencies of _other_ dependencies, but that isn't ideal!)