### PR TITLE
Fix ability to reorder components

### DIFF
--- a/lib/admin/route/admin.instance.property/admin.instance.property.controller.js
+++ b/lib/admin/route/admin.instance.property/admin.instance.property.controller.js
@@ -52,8 +52,8 @@ const {
   isUploadSummaryPage
 } = require('~/fb-editor-node/lib/admin/common/components/upload')
 
-const includeUploadSteps = (step) => isUploadCheckPage(getDiscreteInstance(step)) || isUploadSummaryPage(getDiscreteInstance(step))
-const excludeUploadSteps = (step) => !isUploadCheckPage(getDiscreteInstance(step)) && !isUploadSummaryPage(getDiscreteInstance(step))
+const includeUploadSteps = (step) => isUploadCheckPage(getDiscreteInstance(step._id)) || isUploadSummaryPage(getDiscreteInstance(step._id))
+const excludeUploadSteps = (step) => !isUploadCheckPage(getDiscreteInstance(step._id)) && !isUploadSummaryPage(getDiscreteInstance(step._id))
 
 function getPostRedirectToPreviousUrl ({ pageData, pageInstance }) {
   return pageData.getUserDataProperty('previouspage') || pageInstance.adminBack


### PR DESCRIPTION
`getDiscreteInstance` requires a page ID in order to correctly find the required JSON paths. We were passing an object in previously.

https://trello.com/c/isQvJB3y/489-bug-cannot-re-order-components-bug-classification-9