### PR TITLE
Cater for strings and objects when filtering upload component steps

### DIFF
--- a/lib/admin/route/admin.instance.property/admin.instance.property.controller.js
+++ b/lib/admin/route/admin.instance.property/admin.instance.property.controller.js
@@ -52,8 +52,17 @@ const {
   isUploadSummaryPage
 } = require('~/fb-editor-node/lib/admin/common/components/upload')
 
-const includeUploadSteps = (step) => isUploadCheckPage(getDiscreteInstance(step._id)) || isUploadSummaryPage(getDiscreteInstance(step._id))
-const excludeUploadSteps = (step) => !isUploadCheckPage(getDiscreteInstance(step._id)) && !isUploadSummaryPage(getDiscreteInstance(step._id))
+const itemId = (item) => typeof item === 'string' ? item : item._id
+
+function includeUploadSteps (step) {
+  const _id = itemId(step)
+  return isUploadCheckPage(getDiscreteInstance(_id)) || isUploadSummaryPage(getDiscreteInstance(_id))
+}
+
+function excludeUploadSteps (step) {
+  const _id = itemId(step)
+  return !isUploadCheckPage(getDiscreteInstance(_id)) && !isUploadSummaryPage(getDiscreteInstance(_id))
+}
 
 function getPostRedirectToPreviousUrl ({ pageData, pageInstance }) {
   return pageData.getUserDataProperty('previouspage') || pageInstance.adminBack
@@ -331,7 +340,7 @@ function setData (pageInstance, pageData, POST, REFERRER) {
       hiddenValue = hiddenValue
         .filter(excludeUploadSteps)
         .map((item) => {
-          const _id = typeof item === 'string' ? item : item._id
+          const _id = itemId(item)
 
           return {
             _id,


### PR DESCRIPTION
Both the `includeUploadSteps` and `excludeUploadSteps` functions are used to filter upload component steps. The parameter passed to them can either be an object or a string depending on where they are invoked.

We had previously adjusted these functions to fix the reordering of components by making sure an actual ID is passed to `excludeUploadSteps` However `step` at that moment is not guaranteed to be an object.

Here we allow for the parameters to be either.

https://trello.com/c/YYIWc2XK/730-fix-reordering-of-steps