### PR TITLE
Remove edit mode footer navigation

### DIFF
--- a/templates/nunjucks/base.njk.html
+++ b/templates/nunjucks/base.njk.html
@@ -110,20 +110,6 @@
 {% endblock %}
 
 {% block header %}
-{% if page.preview.next or page.preview.previous  %}
-<div class="PreviewSummary-container">
-<div class="PreviewSummary xgovuk-width-container govuk-body-m" role="group" aria-labelledby="preview-summary-heading" tabindex="-1">
-<div class="PreviewSummary__links">
-{% if page.preview.previous %}
-<p class="fb-preview-previous"><a href="{{ page.preview.previous.url }}"><span class="fb-preview-direction">Previous page</span> {{ page.preview.previous.title | safe }}</a></p>
-{% endif %}
-{% if page.preview.next %}
-<p class="fb-preview-next"><a href="{{ page.preview.next.url }}"><span class="fb-preview-direction">Next page</span> {{ page.preview.next.title | safe }}</a></p>
-{% endif %}
-</div>
-</div>
-</div>
-{% endif %}
 
 {% if (page.MODE === 'edit') or (page.MODE === 'preview') %}
 <div class="content-wrapper content-wrapper-{{ page.MODE }}">


### PR DESCRIPTION
We feel that these navigation elements only serve to distract the user.

## Before

<img width="1915" alt="Screenshot 2020-07-21 at 11 33 37" src="https://user-images.githubusercontent.com/3466862/88045121-3ecd1b80-cb46-11ea-8cab-91fd2d1d92cf.png">


## After

<img width="1915" alt="Screenshot 2020-07-21 at 11 21 26" src="https://user-images.githubusercontent.com/3466862/88045154-41c80c00-cb46-11ea-96f9-6a369fe2f1b6.png">



https://trello.com/c/AUsgN1A2/797-remove-edit-view-footer-page-navigation