### PR TITLE
Notify slack on publishing and on failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
 
 jobs:
   lint_and_test:
@@ -15,6 +17,11 @@ jobs:
       - run:
           name: Test
           command: npm run test
+      - slack/status: &slack_status
+          fail_only: true
+          only_for_branches: master
+          failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"
+          include_job_number_field: false
   publish:
     docker:
       - image: circleci/node:12.4.0
@@ -37,7 +44,9 @@ jobs:
             if [ "$VERSION" != "$PUBLISHED_VERSION" ]
             then
               npm publish
+              curl -X POST -H 'Content-type: application/json' --data '{"text":":woohoo:  Successfully published fb-client $VERSION  :ship_it_parrot:"}' "$SLACK_WEBHOOK"
             fi
+      - slack/status: *slack_status
 
 workflows:
   version: 2


### PR DESCRIPTION
We want to be notified on slack when tests fail on master and when a new version is successfully published

https://trello.com/c/myuOzEs3/933-notify-slack-when-deployments-fail-succeed