### PR TITLE
Make checkboxes component required by default

### DIFF
--- a/lib/admin/route/admin.instance.property/admin.instance.property.controller.js
+++ b/lib/admin/route/admin.instance.property/admin.instance.property.controller.js
@@ -447,10 +447,6 @@ function setData (pageInstance, pageData, POST, REFERRER) {
 
   if (value === undefined) {
     value = schemaProperties[property].default
-    if (runtimeInstance._type === 'checkboxes') {
-      value = false
-    }
-
     pageData.setUserDataProperty('value', value)
   }
 


### PR DESCRIPTION
Currently radio list components are mandatory by default, but checkbox list are optional by default.

The more common scenario is for questions to be mandatory, as GDS guidance states we should try to reduce the amount of questions we ask users to only what is absolutely needed.

https://trello.com/c/2JXUB17W/887-editor-make-checkbox-list-components-required-by-default

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>