### PR TITLE
Bump required engine to be Node >=14.20.1 <15.0.0, and update CircleCI image to use node:14.20.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   lint_and_test:
     docker:
-      - image: circleci/node:12.4.0
+      - image: circleci/node:14.20.1
     steps:
       - checkout
       - run:
@@ -24,7 +24,7 @@ jobs:
           include_job_number_field: false
   publish:
     docker:
-      - image: circleci/node:12.4.0
+      - image: circleci/node:14.20.1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   lint_and_test:
     docker:
-      - image: circleci/node:14.20.1
+      - image: cimg/node:14.20.1
     steps:
       - checkout
       - run:
@@ -24,7 +24,7 @@ jobs:
           include_job_number_field: false
   publish:
     docker:
-      - image: circleci/node:14.20.1
+      - image: cimg/node:14.20.1
     steps:
       - checkout
       - run:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ministryofjustice/fb-editor-node",
   "version": "0.2.14",
   "engines": {
-    "node": ">=12.4.0"
+    "node": ">=14.20.1 <15.0.0"
   },
   "description": "Form Builder Editor (for Node)",
   "main": "./index.js",


### PR DESCRIPTION
This PR updates the CircleCI image to use Node v14.20.1, and pins the Node engine version to >=14.20.1 <15.0.0.

This PR also closes #487.